### PR TITLE
Fixed the typo in the hyperlink text 

### DIFF
--- a/docs/_includes/intro.html
+++ b/docs/_includes/intro.html
@@ -19,7 +19,7 @@
 
         <p>We provide support for MQTT. Devices and applications running outside of Cloud Foundry can connect with
         Solace Messaging services running in Cloud Foundry, by using the TCP Routes feature. This features provides
-        endpoints that allow external connections. Please read the <a href="http://dev.solace.com/get-started/mqtt-tutorials/publish-subscribe_mqtt/" target="_top">Solace MQTT Tuturial</a>.The Solace Messaging Cloud Foundry tile documentation describes the TCP Routes feature.
+        endpoints that allow external connections. Please read the <a href="http://dev.solace.com/get-started/mqtt-tutorials/publish-subscribe_mqtt/" target="_top">Solace MQTT Tutorial</a>.The Solace Messaging Cloud Foundry tile documentation describes the TCP Routes feature.
         </p>
 
         <p>Here are a few links you might find interesting if you are new to Solace Messaging in Pivotal Cloud Foundry:</p>


### PR DESCRIPTION
Fixed the typo in the hyperlink text, "...Solace MQTT Tutorial". @mdspielman 